### PR TITLE
feat(compiler): Add support for `break` and `continue` interruptor statements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 lox-c/*.o
 lox-c/clox
+/lox-c/main.lox

--- a/lox-c/compiler.c
+++ b/lox-c/compiler.c
@@ -740,11 +740,11 @@ static void forStatement() {
   // We now patch all the jumps and loops that were defined via interruptor
   // statements.
   for (int i = 0; i < interruptors.count; i++) {
-    InterruptorType type = interruptors.interruptors[i].type;
-    if (type == BREAK) {
-      patchJump(interruptors.interruptors[i].position);
-    } else if (type == CONTINUE) {
-      patchLoop(interruptors.interruptors[i].position, loopStart);
+    Interruptor interruptor = interruptors.interruptors[i];
+    if (interruptor.type == BREAK) {
+      patchJump(interruptor.position);
+    } else if (interruptor.type == CONTINUE) {
+      patchLoop(interruptor.position, loopStart);
     }
   }
 
@@ -801,17 +801,18 @@ static void whileStatement() {
   Interruptors interruptors = statement();
   emitLoop(loopStart);
 
-  patchJump(exitJump);
-
+  // We now patch all the jumps and loops that were defined via interruptor
+  // statements.
   for (int i = 0; i < interruptors.count; i++) {
-    InterruptorType type = interruptors.interruptors[i].type;
-    if (type == BREAK) {
-      patchJump(interruptors.interruptors[i].position);
-    } else if (type == CONTINUE) {
-      patchLoop(interruptors.interruptors[i].position, loopStart);
+    Interruptor interruptor = interruptors.interruptors[i];
+    if (interruptor.type == BREAK) {
+      patchJump(interruptor.position);
+    } else if (interruptor.type == CONTINUE) {
+      patchLoop(interruptor.position, loopStart);
     }
   }
 
+  patchJump(exitJump);
   emitByte(OP_POP); // Condition.
 }
 

--- a/lox-c/compiler.c
+++ b/lox-c/compiler.c
@@ -62,7 +62,8 @@ typedef struct {
 } Interruptor;
 
 typedef struct {
-  Interruptor interruptors[100];
+  // For now we temporarily want to store at most 256 interruptors.
+  Interruptor interruptors[256];
   int count;
 } Interruptors;
 
@@ -75,6 +76,14 @@ typedef struct {
 Parser parser;
 Compiler *current = NULL;
 Chunk *compilingChunk;
+
+static Interruptors mergeInterruptors(Interruptors a, Interruptors b) {
+  for (int i = 0; i < b.count; i++) {
+    a.interruptors[a.count] = b.interruptors[i];
+    a.count++;
+  }
+  return a;
+}
 
 static Chunk *currentChunk() { return compilingChunk; }
 
@@ -497,7 +506,7 @@ static Interruptors block() {
   Interruptors interruptors = NO_INTERRUPTORS;
 
   while (!check(TOKEN_RIGHT_BRACE) && !check(TOKEN_EOF)) {
-    declaration();
+    interruptors = mergeInterruptors(interruptors, declaration());
   }
 
   consume(TOKEN_RIGHT_BRACE, "Expect '}' after block.");

--- a/lox-c/compiler.c
+++ b/lox-c/compiler.c
@@ -263,6 +263,11 @@ static void removeEnclosingContext() {
     return;
   }
 
+  if (enclosingContextsCount == UINT8_COUNT) {
+    errorAtCurrent("Too many nested contexts");
+    return;
+  }
+
   enclosingContexts[enclosingContextsCount - 1] = NONE;
   enclosingContextsCount--;
 }

--- a/lox-c/main.lox
+++ b/lox-c/main.lox
@@ -1,10 +1,19 @@
 var i = 0;
 
-for (i = 0; i < 10; i = i + 1) {
-	for (var j = 0; j < 10; j = j + 1) {
-		print(i + j);
+for (i = 0; i < 3; i = i + 1) {
+	switch (i) {
+		case 0: {
+		print("zero");
 		break;
+		}
+		case 1: {
+			var j = 20;
+			print("one");
+			continue;
+		}
 	}
+
+	print("Before next loop");
 }
 
 print("End");

--- a/lox-c/main.lox
+++ b/lox-c/main.lox
@@ -1,4 +1,0 @@
-for (var i = 0; i < 1; i = i + 1) {
-	print("Before next loop");
-	continue;
-}

--- a/lox-c/main.lox
+++ b/lox-c/main.lox
@@ -1,19 +1,4 @@
-var i = 0;
-
-for (i = 0; i < 3; i = i + 1) {
-	switch (i) {
-		case 0: {
-		print("zero");
-		break;
-		}
-		case 1: {
-			var j = 20;
-			print("one");
-			continue;
-		}
-	}
-
+for (var i = 0; i < 1; i = i + 1) {
 	print("Before next loop");
+	continue;
 }
-
-print("End");

--- a/lox-c/main.lox
+++ b/lox-c/main.lox
@@ -1,13 +1,10 @@
-var i = "hello";
+var i = 0;
 
-switch (i) {
-	case "hello": {
-		print("ciao");
-	}
-	case "world": {
-		print("mondo");
-	}
-	default: {
-		print("Hit default");
+for (i = 0; i < 10; i = i + 1) {
+	for (var j = 0; j < 10; j = j + 1) {
+		print(i + j);
+		break;
 	}
 }
+
+print("End");

--- a/lox-c/scanner.c
+++ b/lox-c/scanner.c
@@ -1,5 +1,4 @@
 #include <stdbool.h>
-#include <stdio.h>
 #include <string.h>
 
 #include "scanner.h"

--- a/lox-c/scanner.c
+++ b/lox-c/scanner.c
@@ -101,6 +101,8 @@ static TokenType identifierType() {
   switch (scanner.start[0]) {
   case 'a':
     return checkKeyword(1, 2, "nd", TOKEN_AND);
+  case 'b':
+    return checkKeyword(1, 4, "reak", TOKEN_BREAK);
   case 'c':
     if (scanner.current - scanner.start > 1) {
       switch (scanner.start[1]) {
@@ -108,6 +110,8 @@ static TokenType identifierType() {
         return checkKeyword(2, 2, "se", TOKEN_CASE);
       case 'l':
         return checkKeyword(2, 3, "ass", TOKEN_CLASS);
+      case 'o':
+        return checkKeyword(2, 6, "ntinue", TOKEN_CONTINUE);
       }
     }
     break;

--- a/lox-c/scanner.h
+++ b/lox-c/scanner.h
@@ -49,6 +49,8 @@ typedef enum {
   TOKEN_SWITCH,
   TOKEN_CASE,
   TOKEN_DEFAULT,
+  TOKEN_BREAK,
+  TOKEN_CONTINUE,
   // Other.
   TOKEN_ERROR,
   TOKEN_EOF


### PR DESCRIPTION
This PR adds the first experimental version of interruptors to the `c-lox` language. The implementation leverages the existing `OP_LOOP` and `OP_JUMP` instructions.

# Implementation Details
The high level of the implementation is that a `break` and `continue` statement is just a forward or backward jump under the hood. The complexity lies in ensuring that the unwinding of any scopes and stack values is done properly.

To achieve this the implementation works in the following way for each of the statements:
`break` -> it is converted to an `OP_JUMP` to the innermost enclosing context that supports the statement. The implementation makes sure to jump right at the instruction that starts the destruction of the statement. Along the way, it also emits the necessary `OP_POP` instructions to free any scoped variables.
`continue` -> it is converted to an `OP_LOOP` to the innermost enclosing context that supports the statement. The implementation is very similar to the `break` statement with the added complexity that `continue` is not supported in a `switch` statement, thus when emitting the `OP_LOOP` we not only have to make sure to deallocate all local variables but also account for the variable instantiated in the `switch` condition.

The tracking of contexts (scopes, special statements...) is done via `EnclosingContext`(s) which is just a stack representing which contexts have been seen during compilation. This stack is used during unwinding to emit the correct instructions to clear the stack. It is also used for correctness since we want to guard against having `continue` or `break` statements that are defined outside of supported statements.